### PR TITLE
Ensure displaying anchors on theme-default with CSS

### DIFF
--- a/assets/plugin.css
+++ b/assets/plugin.css
@@ -24,3 +24,7 @@ h1:hover a.plugin-anchor, h2:hover a.plugin-anchor, h3:hover a.plugin-anchor,
 h4:hover a.plugin-anchor, h5:hover a.plugin-anchor, h6:hover a.plugin-anchor {
     display: inline-block;
 }
+
+.book .book-body .page-wrapper .page-inner section.normal {
+    overflow: visible;
+}


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
As a matter of fact, your plugin is not impacted by the API updates. By while trying it, I had troubles displaying the anchors because of a missing CSS rule.

The [default theme](https://github.com/GitbookIO/theme-default) for GitBook uses a `overflow: hidden` rule on the main content. Hence, the anchors displayed by your plugin, which are out of scope, don't appear. This is usually solved by the following CSS rule added by `gitbook-plugin-comment`:

```CSS
.book .book-body .page-wrapper .page-inner section.normal {
    overflow: visible;
}
```

To ensure your plugin's stand-alone functionality, I think you should embed this CSS rule too.
Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

Kind regards,
Johan