### PR TITLE
Generate header id to work with gitbook 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,17 @@
 var cheerio = require('cheerio');
 var _ = require('lodash');
+var slug = require('github-slugid');
 
 // insert anchor link into section
 function insertAnchors(content) {
     var $ = cheerio.load(content);
     $(':header').each(function(i, elem) {
         var header = $(elem);
-        var id = header.attr('id');
+        var id = header.attr("id");
+        if (!id) {
+            id = slug(header.text());
+            header.attr("id", id);
+        }
         header.prepend('<a name="' + id + '" class="plugin-anchor" '
                    + 'href="#' + id + '">'
                    + '<span class="fa fa-link"></span>'

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     },
     "dependencies": {
         "cheerio": "*",
-        "lodash": "*"
+        "lodash": "*",
+        "github-slugid": "1.0.1"
     }
 }


### PR DESCRIPTION
gitbook 3.0.0 does not seem to generate the `id` attribute for headers before it sends the content to plugins. So, the call to `header.attr('id')` returned `undefined`.

This commit fixes it by generating an `id`.