### PR TITLE
Changes element from span to i to be compatible with latest FA versions

### DIFF
--- a/assets/plugin.css
+++ b/assets/plugin.css
@@ -11,7 +11,7 @@ a.plugin-anchor {
     bottom: 0;
 }
 
-a.plugin-anchor span {
+a.plugin-anchor i {
     margin-left: -25px;
     font-size: 15px !important;
 }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function insertAnchors(content) {
         var id = header.attr('id');
         header.prepend('<a name="' + id + '" class="plugin-anchor" '
                    + 'href="#' + id + '">'
-                   + '<span class="fa fa-link"></span>'
+                   + '<i class="fa fa-link" aria-hidden="true"></i>'
                    + '</a>');
     });
     return $.html();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gitbook-plugin-anchors",
     "description": "Add Github style heading anchors to your Gitbook",
     "main": "index.js",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "license": "Apache-2.0",
     "author": "Bo Marchman <bo.marchman@gmail.com>",
     "engines": {


### PR DESCRIPTION
`<span class="fa fa-link">` was breaking. Latest FontAwesome styles require you to use `<i class="fa fa-link" aria-hidden="true"></i>`, as [described here](http://fontawesome.io/icon/link/).